### PR TITLE
feat!: migrate to arkworks 0.4.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,16 @@
+name: Rust
+
+on: [push, pull_request]
+
+jobs:
+  check_n_test:
+    name: cargo check & test
+    uses: noir-lang/.github/.github/workflows/rust-test.yml@main
+
+  clippy:
+    name: cargo clippy
+    uses: noir-lang/.github/.github/workflows/rust-clippy.yml@main
+
+  format:
+    name: cargo fmt
+    uses: noir-lang/.github/.github/workflows/rust-format.yml@main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,19 @@
 [package]
 name = "grumpkin"
 version = "0.1.0"
+authors = ["The Noir Team <team@noir-lang.org>"]
 edition = "2021"
+license = "MIT"
+rust-version = "1.66"
+repository = "https://github.com/noir-lang/grumpkin/"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ark-ff = { version = "^0.3.0", default-features = false }
-ark-ec = { version = "^0.3.0", default-features = false }
-ark-std = { version = "^0.3.0", default-features = false }
-ark-bn254 = { version = "^0.3.0", default-features = false, features = [
+ark-ff = { version = "^0.4.0", default-features = false }
+ark-ec = { version = "^0.4.0", default-features = false }
+ark-std = { version = "^0.4.0", default-features = false }
+ark-bn254 = { version = "^0.4.0", default-features = false, features = [
     "scalar_field",
     "curve",
 ] }

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -1,12 +1,9 @@
 use crate::{Fq, Fr};
-use ark_ec::{
-    models::ModelParameters,
-    short_weierstrass_jacobian::{
-        GroupAffine as SWGroupAffine, GroupProjective as SWGroupProjective,
-    },
-    SWModelParameters,
+use ark_ec::models::{
+    short_weierstrass::{Affine as SWGroupAffine, Projective as SWGroupProjective, SWCurveConfig},
+    CurveConfig,
 };
-use ark_ff::{field_new, Zero};
+use ark_ff::{Field, MontFp, Zero};
 
 pub type SWAffine = SWGroupAffine<GrumpkinParameters>;
 pub type SWProjective = SWGroupProjective<GrumpkinParameters>;
@@ -14,40 +11,36 @@ pub type SWProjective = SWGroupProjective<GrumpkinParameters>;
 #[derive(Clone, Default, PartialEq, Eq)]
 pub struct GrumpkinParameters;
 
-impl ModelParameters for GrumpkinParameters {
+impl CurveConfig for GrumpkinParameters {
     type BaseField = Fq;
     type ScalarField = Fr;
-}
-
-/// x coordinate for SW curve generator
-/// value is 1
-const SW_GENERATOR_X: Fq = field_new!(Fq, "1");
-/// y coordinate for SW curve generator
-/// value is sqrt(-15)
-const SW_GENERATOR_Y: Fq = field_new!(
-    Fq,
-    "17631683881184975370165255887551781615748388533673675138860"
-);
-
-impl SWModelParameters for GrumpkinParameters {
-    /// COEFF_A = 0
-    const COEFF_A: Self::BaseField = field_new!(Fq, "0");
-
-    /// COEFF_B = -17
-    const COEFF_B: Self::BaseField = field_new!(Fq, "-17");
 
     /// COFACTOR = 1
     const COFACTOR: &'static [u64] = &[1];
 
     /// COFACTOR^(-1) mod r = 1
-    const COFACTOR_INV: Fr = field_new!(Fr, "1");
+    const COFACTOR_INV: Fr = Fr::ONE;
+}
 
-    /// generators
-    const AFFINE_GENERATOR_COEFFS: (Self::BaseField, Self::BaseField) =
-        (SW_GENERATOR_X, SW_GENERATOR_Y);
+/// x coordinate for SW curve generator
+/// value is 1
+const SW_GENERATOR_X: Fq = Fq::ONE;
+/// y coordinate for SW curve generator
+/// value is sqrt(-15)
+const SW_GENERATOR_Y: Fq = MontFp!("17631683881184975370165255887551781615748388533673675138860");
+
+impl SWCurveConfig for GrumpkinParameters {
+    /// COEFF_A = 0
+    const COEFF_A: Self::BaseField = Fq::ZERO;
+
+    /// COEFF_B = -17
+    const COEFF_B: Self::BaseField = MontFp!("-17");
+
+    /// AFFINE_GENERATOR_COEFFS = (G1_GENERATOR_X, G1_GENERATOR_Y)
+    const GENERATOR: SWAffine = SWAffine::new_unchecked(SW_GENERATOR_X, SW_GENERATOR_Y);
 
     #[inline(always)]
-    fn mul_by_a(_: &Self::BaseField) -> Self::BaseField {
+    fn mul_by_a(_: Self::BaseField) -> Self::BaseField {
         Self::BaseField::zero()
     }
 }

--- a/src/fields/fq.rs
+++ b/src/fields/fq.rs
@@ -1,1 +1,1 @@
-pub use ark_bn254::{Fr as Fq, FrParameters as FqParameters};
+pub use ark_bn254::{Fr as Fq, FrConfig as FqConfig};

--- a/src/fields/fr.rs
+++ b/src/fields/fr.rs
@@ -1,1 +1,1 @@
-pub use ark_bn254::{Fq as Fr, FqParameters as FrParameters};
+pub use ark_bn254::{Fq as Fr, FqConfig as FrConfig};


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

## Summary\*

This PR migrates this package to target arkworks 0.4.0 to match the version used by ACVM.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
